### PR TITLE
회원 로그인 기능 구현

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,6 +1206,7 @@ dependencies = [
  "chrono",
  "email_address",
  "rand",
+ "rocket",
  "rust-argon2",
  "serde",
  "sqlx",

--- a/crates/auth_authn_server/src/routes/before_signup/accept_signup/repository/create_user.rs
+++ b/crates/auth_authn_server/src/routes/before_signup/accept_signup/repository/create_user.rs
@@ -36,7 +36,7 @@ impl CreateUserContract for super::Repository {
     }
 }
 
-fn query<'args>(user_pk: UserPrimaryKey, user_id: UserIdentity) -> QueryBuilder<'args> {
+fn query<'q>(user_pk: UserPrimaryKey, user_id: UserIdentity) -> QueryBuilder<'q> {
     QueryBuilder::new()
         .insert_into(User, &[user::columns::USER_PK, user::columns::ID])
         .values(|builder| {

--- a/crates/auth_authn_server/src/routes/session/login/mod.rs
+++ b/crates/auth_authn_server/src/routes/session/login/mod.rs
@@ -1,10 +1,53 @@
+mod repository;
 mod request;
+mod response;
+mod service;
 
+use database_toolkit::DatabaseConnectionPool;
 use guard::IpAddrRateLimit;
+use new_type::IpAddr;
+use repository::*;
 use request::*;
-use rocket::serde::json::Json;
+use response::*;
+use rocket::{http::Status, serde::json::Json, State};
+use service::*;
 
 #[post("/login", data = "<body>")]
-pub async fn handler(_rate_limit: IpAddrRateLimit, body: Json<Data>) {
-    dbg!(&body);
+pub async fn handler(
+    _rate_limit: IpAddrRateLimit,
+    ip_addr: IpAddr,
+    pool: &State<DatabaseConnectionPool>,
+    body: Json<Data>,
+) -> Result<Response, Status> {
+    let service = service(pool.inner().clone(), Repository, ip_addr, body);
+    match service.execute().await {
+        Ok(response) => Ok(Response {
+            body: Json(Body {
+                expired_password: response.expired_password,
+            }),
+        }),
+        Err(ServiceError::FindPasswordByEmailAddress(_)) => Err(Status::Unauthorized),
+        Err(ServiceError::PasswordMismatch) => Err(Status::Unauthorized),
+        _ => Err(Status::InternalServerError),
+    }
+}
+
+fn service(
+    pool: DatabaseConnectionPool,
+    repository: Repository,
+    ip_address: IpAddr,
+    body: Json<Data>,
+) -> Service<Repository> {
+    let Data {
+        email_address,
+        password,
+    } = body.into_inner();
+
+    Service {
+        pool,
+        repository,
+        email_address,
+        password,
+        ip_address,
+    }
 }

--- a/crates/auth_authn_server/src/routes/session/login/repository/create_session.rs
+++ b/crates/auth_authn_server/src/routes/session/login/repository/create_session.rs
@@ -1,0 +1,90 @@
+use auth_database::{
+    user::columns::UserPrimaryKey,
+    user_session::{
+        self,
+        columns::{UserSessionExpiredAt, UserSessionIdentity, UserSessionPrimaryKey},
+        UserSession,
+    },
+};
+use database_toolkit::{DatabaseConnection, QueryBuilder};
+use new_type::IpAddr;
+
+pub trait CreateSessionContract {
+    async fn create_session(
+        &self,
+        connection: DatabaseConnection,
+        user_session_pk: UserSessionPrimaryKey,
+        user_session_id: UserSessionIdentity,
+        user_pk: UserPrimaryKey,
+        ip_address: IpAddr,
+        expired_at: UserSessionExpiredAt,
+    ) -> Result<(), CreateSessionError>;
+}
+
+#[derive(Debug)]
+pub enum CreateSessionError {
+    Database(sqlx::Error),
+}
+
+impl CreateSessionContract for super::Repository {
+    async fn create_session(
+        &self,
+        mut connection: DatabaseConnection,
+        user_session_pk: UserSessionPrimaryKey,
+        user_session_id: UserSessionIdentity,
+        user_pk: UserPrimaryKey,
+        ip_address: IpAddr,
+        expired_at: UserSessionExpiredAt,
+    ) -> Result<(), CreateSessionError> {
+        query(
+            user_session_pk,
+            user_session_id,
+            user_pk,
+            ip_address,
+            expired_at,
+        )
+        .build()
+        .execute(&mut *connection)
+        .await
+        .map_err(CreateSessionError::Database)?;
+
+        Ok(())
+    }
+}
+
+fn query<'q>(
+    user_session_pk: UserSessionPrimaryKey,
+    user_session_id: UserSessionIdentity,
+    user_pk: UserPrimaryKey,
+    ip_address: IpAddr,
+    expired_at: UserSessionExpiredAt,
+) -> QueryBuilder<'q> {
+    QueryBuilder::new()
+        .insert_into(
+            UserSession,
+            &[
+                user_session::columns::USER_SESSION_PK,
+                user_session::columns::ID,
+                user_session::columns::USER_PK,
+                user_session::columns::IP_ADDRESS,
+                user_session::columns::EXPIRED_AT,
+            ],
+        )
+        .values(|builder| {
+            builder.nested(|builder| {
+                let user_session_pk: Vec<u8> = user_session_pk.into();
+                let user_session_id: Vec<u8> = user_session_id.into();
+                let user_pk: Vec<u8> = user_pk.into();
+                let ip_address: Vec<u8> = ip_address.into();
+                let expired_at = expired_at.naive_utc();
+
+                builder
+                    .separated(
+                        [user_session_pk, user_session_id, user_pk, ip_address].into_iter(),
+                        |builder, value| builder.value(value),
+                    )
+                    .comma()
+                    .value(expired_at)
+            })
+        })
+}

--- a/crates/auth_authn_server/src/routes/session/login/repository/find_user_by_email_address.rs
+++ b/crates/auth_authn_server/src/routes/session/login/repository/find_user_by_email_address.rs
@@ -1,0 +1,106 @@
+use auth_database::{
+    hasher::columns::HasherPrimaryKey,
+    user::columns::UserPrimaryKey,
+    user_credential::{self, UserCredential},
+    user_credential__has__hasher::{
+        self,
+        columns::{UserCredentialHasHasherExpiredAt, UserCredentialHasHasherHash},
+        UserCredentialHasHasher,
+    },
+};
+use database_toolkit::{DatabaseConnection, QueryBuilder};
+use new_type::EmailAddress;
+use sqlx::FromRow;
+
+pub trait FindUserByEmailAddressContract {
+    async fn find_password_by_email_address(
+        &self,
+        connection: DatabaseConnection,
+        email_address: EmailAddress,
+    ) -> Result<FindUserByEmailAddressEntity, FindUserByEmailAddressError>;
+}
+
+pub struct FindUserByEmailAddressEntity {
+    pub user_pk: UserPrimaryKey,
+    pub hasher_pk: HasherPrimaryKey,
+    pub hash: UserCredentialHasHasherHash,
+    pub expired_at: UserCredentialHasHasherExpiredAt,
+}
+
+#[derive(Debug)]
+pub enum FindUserByEmailAddressError {
+    Database(sqlx::Error),
+    Row(sqlx::Error),
+    EmailAddressNotFound,
+    UserPrimaryKey,
+    HasherPrimaryKey,
+}
+
+impl FindUserByEmailAddressContract for super::Repository {
+    async fn find_password_by_email_address(
+        &self,
+        mut connection: DatabaseConnection,
+        email_address: EmailAddress,
+    ) -> Result<FindUserByEmailAddressEntity, FindUserByEmailAddressError> {
+        #[derive(FromRow)]
+        struct Row {
+            user_pk: Vec<u8>,
+            hasher_pk: Vec<u8>,
+            hash: String,
+            expired_at: chrono::NaiveDateTime,
+        }
+
+        let row = query(email_address)
+            .build()
+            .fetch_optional(&mut *connection)
+            .await
+            .map_err(FindUserByEmailAddressError::Database)?
+            .ok_or(FindUserByEmailAddressError::EmailAddressNotFound)?;
+        let row = Row::from_row(&row).map_err(FindUserByEmailAddressError::Row)?;
+        let user_pk = row
+            .user_pk
+            .try_into()
+            .map_err(|_| FindUserByEmailAddressError::UserPrimaryKey)?;
+        let hasher_pk = HasherPrimaryKey::try_from(row.hasher_pk)
+            .map_err(|_| FindUserByEmailAddressError::HasherPrimaryKey)?;
+        let hash = row.hash.into();
+        let expired_at = row.expired_at.into();
+
+        Ok(FindUserByEmailAddressEntity {
+            user_pk,
+            hasher_pk,
+            hash,
+            expired_at,
+        })
+    }
+}
+
+fn query<'q>(email_address: EmailAddress) -> QueryBuilder<'q> {
+    QueryBuilder::new()
+        .select(UserCredential, |builder| {
+            builder
+                .column(user_credential::columns::USER_PK)
+                .comma()
+                .column(user_credential__has__hasher::columns::HASHER_PK)
+                .comma()
+                .column(user_credential__has__hasher::columns::HASH)
+                .comma()
+                .column(user_credential__has__hasher::columns::EXPIRED_AT)
+        })
+        .join(UserCredentialHasHasher, |builder| {
+            builder
+                .column(user_credential__has__hasher::columns::USER_CREDENTIAL_PK)
+                .eq()
+                .column(user_credential::columns::USER_CREDENTIAL_PK)
+        })
+        .where_(|builder| {
+            let email_address = email_address.as_str().to_owned();
+
+            builder.condition(|builder| {
+                builder
+                    .column(user_credential::columns::EXTERNAL_ID)
+                    .eq()
+                    .value(email_address)
+            })
+        })
+}

--- a/crates/auth_authn_server/src/routes/session/login/repository/mod.rs
+++ b/crates/auth_authn_server/src/routes/session/login/repository/mod.rs
@@ -1,0 +1,15 @@
+pub mod create_session;
+pub mod find_user_by_email_address;
+
+use create_session::*;
+use find_user_by_email_address::*;
+
+pub trait RepositoryContract: FindUserByEmailAddressContract + CreateSessionContract {
+    //
+}
+
+pub struct Repository;
+
+impl RepositoryContract for Repository {
+    //
+}

--- a/crates/auth_authn_server/src/routes/session/login/response.rs
+++ b/crates/auth_authn_server/src/routes/session/login/response.rs
@@ -1,0 +1,11 @@
+use rocket::serde::json::Json;
+
+#[derive(Responder)]
+pub struct Response {
+    pub body: Json<Body>,
+}
+
+#[derive(Serialize)]
+pub struct Body {
+    pub expired_password: bool,
+}

--- a/crates/auth_authn_server/src/routes/session/login/service.rs
+++ b/crates/auth_authn_server/src/routes/session/login/service.rs
@@ -1,0 +1,94 @@
+use super::{
+    create_session::CreateSessionError, find_user_by_email_address::FindUserByEmailAddressError,
+    RepositoryContract,
+};
+use crate::routes::session::login::find_user_by_email_address::FindUserByEmailAddressEntity;
+use auth_database::{
+    hasher,
+    user_session::columns::{UserSessionIdentity, UserSessionPrimaryKey},
+};
+use database_toolkit::DatabaseConnectionPool;
+use new_type::{EmailAddress, Hasher, HasherError, IpAddr, Password};
+
+pub trait ServiceContract {
+    async fn execute(&self) -> Result<Executed, ServiceError>;
+}
+
+pub struct Executed {
+    pub expired_password: bool,
+}
+
+pub struct Service<Repository: RepositoryContract> {
+    pub pool: DatabaseConnectionPool,
+    pub repository: Repository,
+    pub email_address: EmailAddress,
+    pub password: Password,
+    pub ip_address: IpAddr,
+}
+
+#[derive(Debug)]
+pub enum ServiceError {
+    DatabaseConnectionPool(sqlx::Error),
+    FindPasswordByEmailAddress(FindUserByEmailAddressError),
+    Verify(HasherError),
+    PasswordMismatch,
+    CreateSession(CreateSessionError),
+}
+
+impl<Repository: RepositoryContract> ServiceContract for Service<Repository> {
+    async fn execute(&self) -> Result<Executed, ServiceError> {
+        macro_rules! connection {
+            () => {
+                self.pool
+                    .connection()
+                    .await
+                    .map_err(ServiceError::DatabaseConnectionPool)?
+            };
+        }
+
+        let FindUserByEmailAddressEntity {
+            user_pk,
+            hasher_pk,
+            hash,
+            expired_at,
+        } = self
+            .repository
+            .find_password_by_email_address(connection!(), self.email_address.clone())
+            .await
+            .map_err(ServiceError::FindPasswordByEmailAddress)?;
+        let hasher = match hasher_pk.known_kind() {
+            hasher::KnownKind::Argon2 => Hasher::Argon2,
+            hasher::KnownKind::Bcrypt => Hasher::Bcrypt,
+        };
+        if !self
+            .password
+            .verify(hasher, hash.as_ref())
+            .await
+            .map_err(ServiceError::Verify)?
+        {
+            return Err(ServiceError::PasswordMismatch);
+        }
+
+        let now = chrono::Utc::now().naive_utc();
+        {
+            let user_session_pk = UserSessionPrimaryKey::new();
+            let user_session_id = UserSessionIdentity::new();
+            let expired_at = now + chrono::Duration::days(30);
+            self.repository
+                .create_session(
+                    connection!(),
+                    user_session_pk,
+                    user_session_id,
+                    user_pk,
+                    self.ip_address,
+                    expired_at.into(),
+                )
+                .await
+                .map_err(ServiceError::CreateSession)?;
+        }
+
+        Ok(Executed {
+            expired_password: expired_at.naive_utc() < now,
+        })
+    }
+}

--- a/crates/auth_database/build/visitor/column_type_visitor.rs
+++ b/crates/auth_database/build/visitor/column_type_visitor.rs
@@ -478,6 +478,21 @@ impl<'build> Visitor for ColumnTypeVisitor<'build> {
         writeln!(self.file)?;
         writeln!(
             self.file,
+            "        impl From<{}IpAddr> for Vec<u8> {{",
+            self.table_name.to_case(Case::Pascal)
+        )?;
+        writeln!(self.file, "            #[inline]")?;
+        writeln!(
+            self.file,
+            "            fn from(value: {}IpAddr) -> Self {{",
+            self.table_name.to_case(Case::Pascal)
+        )?;
+        writeln!(self.file, "                value.0.into()")?;
+        writeln!(self.file, "            }}")?;
+        writeln!(self.file, "        }}")?;
+        writeln!(self.file)?;
+        writeln!(
+            self.file,
             "        impl std::convert::TryFrom<&[u8]> for {}IpAddr {{",
             self.table_name.to_case(Case::Pascal)
         )?;

--- a/crates/auth_database/src/generated.rs
+++ b/crates/auth_database/src/generated.rs
@@ -1176,6 +1176,13 @@ pub mod user_activity {
             }
         }
 
+        impl From<UserActivityIpAddr> for Vec<u8> {
+            #[inline]
+            fn from(value: UserActivityIpAddr) -> Self {
+                value.0.into()
+            }
+        }
+
         impl std::convert::TryFrom<&[u8]> for UserActivityIpAddr {
             type Error = Vec<u8>;
 
@@ -2143,6 +2150,13 @@ pub mod user_session {
             #[inline]
             fn from(value: u128) -> Self {
                 Self(value.into())
+            }
+        }
+
+        impl From<UserSessionIpAddr> for Vec<u8> {
+            #[inline]
+            fn from(value: UserSessionIpAddr) -> Self {
+                value.0.into()
             }
         }
 

--- a/crates/new_type/Cargo.toml
+++ b/crates/new_type/Cargo.toml
@@ -8,6 +8,7 @@ base58 = { package = "bs58", version = "0.5.0", optional = true }
 chrono = { version = "0.4.33", features = ["now", "serde"], optional = true }
 dep_email_address = { package = "email_address", version = "0.2.4", optional = true }
 rand = { version = "0.8.5", optional = true }
+rocket = { version = "0.5.0", optional = true }
 rust-argon2 = { version = "2.1.0", optional = true }
 serde = { version = "1.0.196", features = ["derive"] }
 sqlx = { version = "0.7", features = [
@@ -31,7 +32,7 @@ default = [
   "image_url",
 ]
 email_address = ["dep:dep_email_address"]
-ip_addr = []
+ip_addr = ["dep:rocket"]
 time = ["dep:chrono"]
 password = ["hash", "dep:rand"]
 hash = ["dep:rust-argon2", "dep:rand", "dep:tokio"]


### PR DESCRIPTION
# 설명

이메일, 패스워드를 입력 받아 계정 인증.

## 변경사항

- user_credential 테이블에 해당 이메일이 있는지 확인
   이메일은 external_id에 있음.
   추후 Google, Facebook 등 여러 소셜 로그인을 지원하기 위한 추상화.

- user_credential__has__hasher 테이블을 조인해 hasher_pk, hash, expired_at 확인
   소셜 로그인은 패스워드 인증을 추가할 필요가 없으므로 따로 분리한 테이블.
   password.verify(hash)를 통과하면 계정 인증 성공.

- hasher가 만료하더라도(`expired_at < now`) 로그인은 통과함
   expired_at은 패스워드 변경 권유를 위한 데이터.

## 추후

- 로그인 이벤트 발생 필요
   이 이벤트를 통해 로그인 안내 이메일 발송해야 함.

