### PR TITLE
계정 정보 조회 기능 구현

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,8 +787,11 @@ version = "0.1.0"
 dependencies = [
  "auth_database",
  "chrono",
+ "database_toolkit",
  "new_type",
  "rocket",
+ "serde",
+ "sqlx",
  "tokio",
 ]
 

--- a/crates/auth_authn_server/src/routes/mod.rs
+++ b/crates/auth_authn_server/src/routes/mod.rs
@@ -1,12 +1,14 @@
 mod before_new_password;
 mod before_signup;
 mod session;
+mod users;
 
 use rocket::{Build, Rocket};
 
 pub fn routes(rocket: Rocket<Build>) -> Rocket<Build> {
     let rocket = before_new_password::routes(rocket);
     let rocket = before_signup::routes(rocket);
+    let rocket = users::routes(rocket);
     let rocket = session::routes(rocket);
 
     rocket

--- a/crates/auth_authn_server/src/routes/users/me/mod.rs
+++ b/crates/auth_authn_server/src/routes/users/me/mod.rs
@@ -1,0 +1,44 @@
+mod repository;
+mod response;
+mod service;
+
+use auth_database::user::columns::UserPrimaryKey;
+use database_toolkit::DatabaseConnectionPool;
+use guard::Session;
+use repository::*;
+use response::*;
+use rocket::{http::Status, serde::json::Json, State};
+use service::*;
+
+#[get("/users/me")]
+pub async fn handler(
+    session: Session,
+    pool: &State<DatabaseConnectionPool>,
+) -> Result<Response, Status> {
+    let service = service(pool.inner().clone(), Repository, session.user_pk);
+    match service.execute().await {
+        Ok(response) => Ok(Response {
+            body: Json(Body {
+                user: User {
+                    handle: response.user.handle,
+                    name: response.user.name,
+                    bio: response.user.bio,
+                    image: response.user.image,
+                },
+            }),
+        }),
+        _ => Err(Status::InternalServerError),
+    }
+}
+
+fn service(
+    pool: DatabaseConnectionPool,
+    repository: Repository,
+    user_pk: UserPrimaryKey,
+) -> Service<Repository> {
+    Service {
+        pool,
+        repository,
+        user_pk,
+    }
+}

--- a/crates/auth_authn_server/src/routes/users/me/mod.rs
+++ b/crates/auth_authn_server/src/routes/users/me/mod.rs
@@ -2,7 +2,7 @@ mod repository;
 mod response;
 mod service;
 
-use auth_database::user::columns::UserPrimaryKey;
+use auth_database::{user::columns::UserPrimaryKey, user_session::columns::UserSessionPrimaryKey};
 use database_toolkit::DatabaseConnectionPool;
 use guard::Session;
 use repository::*;
@@ -15,7 +15,12 @@ pub async fn handler(
     session: Session,
     pool: &State<DatabaseConnectionPool>,
 ) -> Result<Response, Status> {
-    let service = service(pool.inner().clone(), Repository, session.user_pk);
+    let service = service(
+        pool.inner().clone(),
+        Repository,
+        session.user_pk,
+        session.user_session_pk,
+    );
     match service.execute().await {
         Ok(response) => Ok(Response {
             body: Json(Body {
@@ -35,10 +40,12 @@ fn service(
     pool: DatabaseConnectionPool,
     repository: Repository,
     user_pk: UserPrimaryKey,
+    user_session_pk: UserSessionPrimaryKey,
 ) -> Service<Repository> {
     Service {
         pool,
         repository,
         user_pk,
+        user_session_pk,
     }
 }

--- a/crates/auth_authn_server/src/routes/users/me/repository/extend_session.rs
+++ b/crates/auth_authn_server/src/routes/users/me/repository/extend_session.rs
@@ -1,0 +1,53 @@
+use auth_database::user_session::{self, columns::UserSessionPrimaryKey, UserSession};
+use chrono::{DateTime, Utc};
+use database_toolkit::{DatabaseConnection, QueryBuilder};
+
+pub trait ExtendSessionContract {
+    async fn extend_session(
+        &self,
+        connection: DatabaseConnection,
+        user_session_pk: UserSessionPrimaryKey,
+        expired_at: DateTime<Utc>,
+    ) -> Result<(), ExtendSessionError>;
+}
+
+#[derive(Debug)]
+pub enum ExtendSessionError {
+    Database(sqlx::Error),
+}
+
+impl ExtendSessionContract for super::Repository {
+    async fn extend_session(
+        &self,
+        mut connection: DatabaseConnection,
+        user_session_pk: UserSessionPrimaryKey,
+        expired_at: DateTime<Utc>,
+    ) -> Result<(), ExtendSessionError> {
+        query(user_session_pk, expired_at)
+            .build()
+            .execute(&mut *connection)
+            .await
+            .map_err(ExtendSessionError::Database)?;
+
+        Ok(())
+    }
+}
+
+fn query<'q>(
+    user_session_pk: UserSessionPrimaryKey,
+    expired_at: DateTime<Utc>,
+) -> QueryBuilder<'q> {
+    QueryBuilder::new()
+        .update(UserSession)
+        .set(user_session::columns::EXPIRED_AT, expired_at)
+        .where_(|builder| {
+            builder.condition(|builder| {
+                let user_session_pk: Vec<u8> = user_session_pk.into();
+
+                builder
+                    .column(user_session::columns::USER_SESSION_PK)
+                    .eq()
+                    .value(user_session_pk)
+            })
+        })
+}

--- a/crates/auth_authn_server/src/routes/users/me/repository/find_user_profile_by_primary_key.rs
+++ b/crates/auth_authn_server/src/routes/users/me/repository/find_user_profile_by_primary_key.rs
@@ -1,0 +1,86 @@
+use auth_database::{
+    user::columns::UserPrimaryKey,
+    user_profile::{self, UserProfile},
+};
+use database_toolkit::{DatabaseConnection, QueryBuilder};
+use sqlx::FromRow;
+
+pub trait FindUserProfileByPrimaryKeyContract {
+    async fn find_user_profile_by_primary_key(
+        &self,
+        connection: DatabaseConnection,
+        user_pk: UserPrimaryKey,
+    ) -> Result<FindUserProfileByPrimaryKeyEntity, FindUserProfileByPrimaryKeyError>;
+}
+
+pub struct FindUserProfileByPrimaryKeyEntity {
+    pub handle: String,
+    pub name: String,
+    pub bio: String,
+    pub image: String,
+}
+
+#[derive(Debug)]
+pub enum FindUserProfileByPrimaryKeyError {
+    Database(sqlx::Error),
+    Row(sqlx::Error),
+}
+
+impl FindUserProfileByPrimaryKeyContract for super::Repository {
+    async fn find_user_profile_by_primary_key(
+        &self,
+        mut connection: DatabaseConnection,
+        user_pk: UserPrimaryKey,
+    ) -> Result<FindUserProfileByPrimaryKeyEntity, FindUserProfileByPrimaryKeyError> {
+        let row = query(user_pk)
+            .build()
+            .fetch_one(&mut *connection)
+            .await
+            .map_err(FindUserProfileByPrimaryKeyError::Database)?;
+
+        #[derive(FromRow)]
+        struct Row {
+            handle: String,
+            name: String,
+            bio: String,
+            image: String,
+        }
+
+        let Row {
+            handle,
+            name,
+            bio,
+            image,
+        } = Row::from_row(&row).map_err(FindUserProfileByPrimaryKeyError::Row)?;
+
+        Ok(FindUserProfileByPrimaryKeyEntity {
+            handle,
+            name,
+            bio,
+            image,
+        })
+    }
+}
+
+fn query<'q>(user_pk: UserPrimaryKey) -> QueryBuilder<'q> {
+    QueryBuilder::new()
+        .select(UserProfile, |builder| {
+            builder.columns(&[
+                user_profile::columns::HANDLE,
+                user_profile::columns::NAME,
+                user_profile::columns::BIO,
+                user_profile::columns::IMAGE,
+            ])
+        })
+        .where_(|builder| {
+            builder.condition(|builder| {
+                let user_pk: Vec<u8> = user_pk.into();
+
+                builder
+                    .column(user_profile::columns::USER_PK)
+                    .eq()
+                    .value(user_pk)
+            })
+        })
+        .limit_offset(1, 0)
+}

--- a/crates/auth_authn_server/src/routes/users/me/repository/mod.rs
+++ b/crates/auth_authn_server/src/routes/users/me/repository/mod.rs
@@ -1,0 +1,13 @@
+pub mod find_user_profile_by_primary_key;
+
+use find_user_profile_by_primary_key::*;
+
+pub trait RepositoryContract: FindUserProfileByPrimaryKeyContract {
+    //
+}
+
+pub struct Repository;
+
+impl RepositoryContract for Repository {
+    //
+}

--- a/crates/auth_authn_server/src/routes/users/me/repository/mod.rs
+++ b/crates/auth_authn_server/src/routes/users/me/repository/mod.rs
@@ -1,8 +1,10 @@
+pub mod extend_session;
 pub mod find_user_profile_by_primary_key;
 
+use extend_session::*;
 use find_user_profile_by_primary_key::*;
 
-pub trait RepositoryContract: FindUserProfileByPrimaryKeyContract {
+pub trait RepositoryContract: FindUserProfileByPrimaryKeyContract + ExtendSessionContract {
     //
 }
 

--- a/crates/auth_authn_server/src/routes/users/me/response.rs
+++ b/crates/auth_authn_server/src/routes/users/me/response.rs
@@ -1,0 +1,19 @@
+use rocket::serde::json::Json;
+
+#[derive(Responder)]
+pub struct Response {
+    pub body: Json<Body>,
+}
+
+#[derive(Serialize)]
+pub struct Body {
+    pub user: User,
+}
+
+#[derive(Serialize)]
+pub struct User {
+   pub handle: String,
+   pub name: String,
+   pub bio: String,
+   pub image: String,
+}

--- a/crates/auth_authn_server/src/routes/users/me/service.rs
+++ b/crates/auth_authn_server/src/routes/users/me/service.rs
@@ -1,0 +1,60 @@
+use super::{
+    find_user_profile_by_primary_key::FindUserProfileByPrimaryKeyError, RepositoryContract,
+};
+use auth_database::user::columns::UserPrimaryKey;
+use database_toolkit::DatabaseConnectionPool;
+
+pub trait ServiceContract {
+    async fn execute(&self) -> Result<Executed, ServiceError>;
+}
+
+pub struct Executed {
+    pub user: UserEntity,
+}
+
+pub struct UserEntity {
+    pub handle: String,
+    pub name: String,
+    pub bio: String,
+    pub image: String,
+}
+
+#[derive(Debug)]
+pub enum ServiceError {
+    DatabaseConnectionPool(sqlx::Error),
+    FindUserProfileByPrimaryKey(FindUserProfileByPrimaryKeyError),
+}
+
+pub struct Service<Repository: RepositoryContract> {
+    pub pool: DatabaseConnectionPool,
+    pub repository: Repository,
+    pub user_pk: UserPrimaryKey,
+}
+
+impl<Repository: RepositoryContract> ServiceContract for Service<Repository> {
+    async fn execute(&self) -> Result<Executed, ServiceError> {
+        macro_rules! connection {
+            () => {
+                self.pool
+                    .connection()
+                    .await
+                    .map_err(ServiceError::DatabaseConnectionPool)?
+            };
+        }
+
+        let user = self
+            .repository
+            .find_user_profile_by_primary_key(connection!(), self.user_pk.clone())
+            .await
+            .map_err(ServiceError::FindUserProfileByPrimaryKey)?;
+
+        Ok(Executed {
+            user: UserEntity {
+                handle: user.handle,
+                name: user.name,
+                bio: user.bio,
+                image: user.image,
+            },
+        })
+    }
+}

--- a/crates/auth_authn_server/src/routes/users/me/service.rs
+++ b/crates/auth_authn_server/src/routes/users/me/service.rs
@@ -1,7 +1,8 @@
 use super::{
+    extend_session::ExtendSessionError,
     find_user_profile_by_primary_key::FindUserProfileByPrimaryKeyError, RepositoryContract,
 };
-use auth_database::user::columns::UserPrimaryKey;
+use auth_database::{user::columns::UserPrimaryKey, user_session::columns::UserSessionPrimaryKey};
 use database_toolkit::DatabaseConnectionPool;
 
 pub trait ServiceContract {
@@ -23,11 +24,13 @@ pub struct UserEntity {
 pub enum ServiceError {
     DatabaseConnectionPool(sqlx::Error),
     FindUserProfileByPrimaryKey(FindUserProfileByPrimaryKeyError),
+    ExtendSession(ExtendSessionError),
 }
 
 pub struct Service<Repository: RepositoryContract> {
     pub pool: DatabaseConnectionPool,
     pub repository: Repository,
+    pub user_session_pk: UserSessionPrimaryKey,
     pub user_pk: UserPrimaryKey,
 }
 
@@ -44,9 +47,15 @@ impl<Repository: RepositoryContract> ServiceContract for Service<Repository> {
 
         let user = self
             .repository
-            .find_user_profile_by_primary_key(connection!(), self.user_pk.clone())
+            .find_user_profile_by_primary_key(connection!(), self.user_pk)
             .await
             .map_err(ServiceError::FindUserProfileByPrimaryKey)?;
+
+        let expired_at = chrono::Utc::now() + chrono::Duration::days(30);
+        self.repository
+            .extend_session(connection!(), self.user_session_pk, expired_at)
+            .await
+            .map_err(ServiceError::ExtendSession)?;
 
         Ok(Executed {
             user: UserEntity {

--- a/crates/auth_authn_server/src/routes/users/mod.rs
+++ b/crates/auth_authn_server/src/routes/users/mod.rs
@@ -1,0 +1,7 @@
+mod me;
+
+use rocket::{Build, Rocket};
+
+pub fn routes(rocket: Rocket<Build>) -> Rocket<Build> {
+    rocket.mount("/", routes![me::handler])
+}

--- a/crates/auth_database/src/identity.rs
+++ b/crates/auth_database/src/identity.rs
@@ -77,6 +77,16 @@ impl<P: Prefix> TryFrom<Vec<u8>> for Identity<P> {
         Ok(Self(value.try_into()?))
     }
 }
+
+impl<P: Prefix> std::str::FromStr for Identity<P> {
+    type Err = identity::PrefixKeyError;
+
+    #[inline]
+    fn from_str(source: &str) -> Result<Self, Self::Err> {
+        Ok(Self(source.parse()?))
+    }
+}
+
 impl<T> PrimaryKey<T> {
     #[inline]
     pub fn new() -> Self {

--- a/crates/guard/Cargo.toml
+++ b/crates/guard/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [dependencies]
 auth_database = { path = "../auth_database" }
 chrono = "0.4.34"
+database_toolkit = { path = "../database_toolkit" }
 new_type = { path = "../new_type" }
 rocket = "0.5.0"
+serde = { version = "1.0.196", features = ["derive"] }
+sqlx = { version = "0.7", features = ["macros", "chrono"] }
 tokio = "1.36.0"

--- a/crates/guard/src/lib.rs
+++ b/crates/guard/src/lib.rs
@@ -3,6 +3,12 @@
 #[macro_use]
 extern crate rocket;
 
+#[macro_use]
+extern crate sqlx;
+
+#[macro_use]
+extern crate serde;
+
 mod data_guard;
 mod fairing;
 mod request_guard;

--- a/crates/guard/src/request_guard/header.rs
+++ b/crates/guard/src/request_guard/header.rs
@@ -1,0 +1,104 @@
+mod authorization;
+mod bearer;
+mod credential;
+
+pub use authorization::*;
+pub use bearer::*;
+pub use credential::*;
+
+use rocket::{
+    http::{HeaderMap, Status},
+    request::{FromRequest, Outcome},
+    serde::Deserialize,
+    Request,
+};
+
+pub trait HeaderName: Sized + Send {
+    const NAME: &'static str;
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Header<T>(T);
+
+impl<T> std::ops::Deref for Header<T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+#[rocket::async_trait]
+impl<'r, T> FromRequest<'r> for Header<T>
+where
+    T: HeaderName + std::str::FromStr,
+{
+    type Error = ();
+
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        match request.headers().try_into() {
+            Ok(header) => Outcome::Success(header),
+            Err(_) => Outcome::Forward(Status::BadRequest),
+        }
+    }
+}
+
+impl<T> TryFrom<&HeaderMap<'_>> for Header<T>
+where
+    T: HeaderName + std::str::FromStr,
+{
+    type Error = ();
+
+    fn try_from(headers: &HeaderMap<'_>) -> Result<Self, Self::Error> {
+        let Some(header) = headers.get(T::NAME).last() else {
+            return Err(());
+        };
+        let Ok(header) = T::from_str(&header) else {
+            return Err(());
+        };
+
+        Ok(Header(header))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rocket::http::{Header, HeaderMap};
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct CustomHeader {
+        value: String,
+    }
+
+    impl std::str::FromStr for CustomHeader {
+        type Err = ();
+
+        fn from_str(source: &str) -> Result<Self, Self::Err> {
+            Ok(CustomHeader {
+                value: source.to_string(),
+            })
+        }
+    }
+
+    impl super::HeaderName for CustomHeader {
+        const NAME: &'static str = "X-Custom-Header";
+    }
+
+    #[test]
+    fn uncased_key() {
+        let headers = {
+            let mut headers = HeaderMap::new();
+            headers.add(Header::new("x-custom-header", "value"));
+            headers
+        };
+        let header = super::Header::<CustomHeader>::try_from(&headers);
+
+        assert_eq!(
+            header,
+            Ok(super::Header(CustomHeader {
+                value: "value".to_string()
+            }))
+        );
+    }
+}

--- a/crates/guard/src/request_guard/header/authorization.rs
+++ b/crates/guard/src/request_guard/header/authorization.rs
@@ -1,0 +1,41 @@
+use crate::{Bearer, Credential, HeaderName};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Authorization<T: Credential>(T);
+
+impl<T> std::ops::Deref for Authorization<T>
+where
+    T: Credential,
+{
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> std::str::FromStr for Authorization<T>
+where
+    T: std::str::FromStr + Credential,
+{
+    type Err = T::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Authorization(s.parse()?))
+    }
+}
+
+impl<T> HeaderName for Authorization<T>
+where
+    T: Send + Credential,
+{
+    const NAME: &'static str = "Authorization";
+}
+
+impl Authorization<Bearer> {
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        self.as_ref()
+    }
+}

--- a/crates/guard/src/request_guard/header/bearer.rs
+++ b/crates/guard/src/request_guard/header/bearer.rs
@@ -1,0 +1,36 @@
+use crate::Credential;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Bearer(String);
+
+impl std::ops::Deref for Bearer {
+    type Target = str;
+
+    #[inline]
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for Bearer {
+    #[inline]
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::str::FromStr for Bearer {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.starts_with("Bearer ") {
+            Ok(Bearer(s[7..].to_string()))
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl Credential for Bearer {
+    //
+}

--- a/crates/guard/src/request_guard/header/credential.rs
+++ b/crates/guard/src/request_guard/header/credential.rs
@@ -1,0 +1,3 @@
+pub trait Credential: Sized {
+    //
+}

--- a/crates/guard/src/request_guard/mod.rs
+++ b/crates/guard/src/request_guard/mod.rs
@@ -1,7 +1,9 @@
+mod header;
 mod ip_addr_rate_limiter;
 mod rate_limiter;
 mod session;
 
+pub use header::*;
 pub use ip_addr_rate_limiter::*;
 pub use rate_limiter::*;
 pub use session::*;

--- a/crates/guard/src/request_guard/session.rs
+++ b/crates/guard/src/request_guard/session.rs
@@ -1,6 +1,86 @@
-use auth_database::user;
+use crate::{Authorization, Bearer, Header};
+use auth_database::{
+    user::{self, columns::UserPrimaryKey},
+    user_session::{self, columns::UserSessionIdentity, UserSession},
+};
+use database_toolkit::{DatabaseConnectionPool, QueryBuilder};
+use rocket::{
+    http::Status,
+    request::{FromRequest, Outcome},
+    Request, State,
+};
+use sqlx::FromRow;
+use std::str::FromStr;
 
 #[derive(Debug)]
 pub struct Session {
-    pub user_id: user::Identity,
+    pub user_pk: UserPrimaryKey,
+}
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for Session {
+    type Error = ();
+
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        let Outcome::Success(authorization) =
+            request.guard::<Header<Authorization<Bearer>>>().await
+        else {
+            return Outcome::Forward(Status::Unauthorized);
+        };
+        let Ok(session_id) = UserSessionIdentity::from_str(authorization.as_str()) else {
+            return Outcome::Forward(Status::Unauthorized);
+        };
+        let Outcome::Success(pool) = request.guard::<&State<DatabaseConnectionPool>>().await else {
+            return Outcome::Error((Status::InternalServerError, ()));
+        };
+        let Ok(mut connection) = pool.connection().await else {
+            return Outcome::Error((Status::InternalServerError, ()));
+        };
+        let Ok(row) = query(session_id).build().fetch_one(&mut *connection).await else {
+            return Outcome::Forward(Status::Unauthorized);
+        };
+
+        #[derive(FromRow)]
+        struct Row {
+            user_pk: Vec<u8>,
+            expired_at: chrono::DateTime<chrono::Utc>,
+        }
+
+        let Ok(Row {
+            user_pk,
+            expired_at,
+        }) = Row::from_row(&row)
+        else {
+            return Outcome::Forward(Status::Unauthorized);
+        };
+        let now = chrono::Utc::now();
+        if expired_at < now {
+            return Outcome::Forward(Status::Unauthorized);
+        }
+        let Ok(user_pk) = UserPrimaryKey::try_from(user_pk) else {
+            return Outcome::Error((Status::InternalServerError, ()));
+        };
+
+        Outcome::Success(Session { user_pk })
+    }
+}
+
+fn query<'q>(session_id: UserSessionIdentity) -> QueryBuilder<'q> {
+    QueryBuilder::new()
+        .select(UserSession, |builder| {
+            builder.columns(&[
+                user_session::columns::USER_PK,
+                user_session::columns::EXPIRED_AT,
+            ])
+        })
+        .where_(|builder| {
+            builder.condition(|builder| {
+                let session_id: Vec<u8> = session_id.into();
+
+                builder
+                    .column(user_session::columns::ID)
+                    .eq()
+                    .value(session_id)
+            })
+        })
 }

--- a/crates/identity/src/identity.rs
+++ b/crates/identity/src/identity.rs
@@ -40,6 +40,14 @@ impl<P: Prefix> TryFrom<Vec<u8>> for Identity<P> {
     }
 }
 
+impl<P: Prefix> std::str::FromStr for Identity<P> {
+    type Err = PrefixKeyError;
+
+    fn from_str(source: &str) -> Result<Self, Self::Err> {
+        Ok(Self(source.parse()?))
+    }
+}
+
 impl<P: Prefix> Identity<P> {
     #[inline]
     pub fn new() -> Self {
@@ -126,5 +134,13 @@ mod tests {
 
             println!("{:#?}", id);
         }
+    }
+
+    #[ignore]
+    #[test]
+    fn hex_to_base58() {
+        let hex = 0x681049B6D1CC453BA880BC8411216FFF;
+        let identity = unsafe { OrderIdentity::new_unchecked(hex) };
+        dbg!(identity);
     }
 }

--- a/crates/identity/src/primary_key.rs
+++ b/crates/identity/src/primary_key.rs
@@ -172,4 +172,12 @@ mod tests {
             println!("{:#?}", id);
         }
     }
+
+    #[ignore]
+    #[test]
+    fn hex_to_base58() {
+        let hex = 0x681049B6D1CC453BA880BC8411216FFF;
+        let primary_key = unsafe { CredentialPrimaryKey::new_unchecked(hex) };
+        dbg!(primary_key);
+    }
 }


### PR DESCRIPTION
# 설명

본인의 계정 정보를 조회할 수 있는 기능.

## 변경사항

- Header, Authorization 타입 추가

   Rocket이 Header 관련 편의성 타입이 없으므로,
   Request Guard를 기반으로 request headers에서 특정 header를 직접 꺼낼 수 있도록 작업.
   ```rust
   // example
   #[get("/users/me")]
   pub async fn handler(authorization: Authorization<Bearer>) { ... }
   ```

- Session Guard 추가

   세션 정보가 필요한 API 엔드포인트에서 편하게 사용할 수 있는 편의성 타입.
   ```rust
   // example
   #[get("/users/me")]
   pub async fn handler(session: Session) { ... }
   ```

- 계정 정보 조회 기능 구현

   계정 정보 조회 시 이름, 이미지, 핸들 등 응답하며, 세션 만료시간을 연장함.
